### PR TITLE
fix: Link-action scrolling, titles, paddings, and whatsapp positions

### DIFF
--- a/src/components/Product.js
+++ b/src/components/Product.js
@@ -8,9 +8,14 @@ import {
   PinterestShareButton
 } from "react-share";
 import { Link } from 'react-router-dom';
+import { useEffect } from "react";
 
 const Product = props => {
   const [prod, alsoProds] = useLoaderData();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [prod]);
 
   return (
       <>

--- a/src/pages/Products.js
+++ b/src/pages/Products.js
@@ -1,8 +1,13 @@
 import { Link } from 'react-router-dom';
 import { caps_first_letter } from '../utils';
+import { useEffect } from 'react';
 
 const Products = props => {
   const [products, title] = [props.products, props.title];
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [products]);
   
   return (
     <>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -412,7 +412,30 @@
   .whats-img { width: 50px; }
 }
 
-@media screen and (max-width: 576px) {
+@media screen and (max-width: 390px) {
+  .cs {
+    .card-title {
+      font-size: 7vw !important;
+    }
+  }
+
+  #Section2, #Section4 {
+    padding: 50px 20px 80px;
+  }
+
+  #Section3 {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+  
+  #Section5 {
+    .contacto { padding: 10px 0 30px !important; }
+  }
+
+  .also-prod-name {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 @media screen and (min-width: 768px) {
@@ -421,11 +444,16 @@
   }
 
   .also-prod { width: calc((100% - (20px*4)) / 4) !important; }
+
+  .also-prods-title { padding-top: 4rem !important; }
+
+  .whatsapp { margin: 50px; }
 }
 
 @media screen and (max-width: 768px) {
   .also-prod { width: calc((100% - 40px) / 2); }
 }
 
-@media screen and (min-width: 1020px) {
+@media screen and (min-width: 576px) {
+  .whatsapp { margin: 50px; }
 }


### PR DESCRIPTION
## Issue
After clicking a Link, it never starts at the beginning of the page. On very small screens some titles, texts and paragraphs break. And the whatsapp icon doesn't look good on mid and large screen sizes.

## Screenshots
• ![Screenshot 2023-10-04 231731](https://github.com/NewIncome/mi-eco-tiendita_react/assets/42077060/d8841530-b1f0-4652-baae-3f825459eefe)
• ![Screenshot 2023-10-04 231753](https://github.com/NewIncome/mi-eco-tiendita_react/assets/42077060/a55a0d90-5e19-4df6-ab03-7ed9e8f7ea24)


## Procedure
+ Fix Home#Categorias: img-Text sizes -sm
+ Fix Home#QuienesSomos: Paragraph padding -sm;  &#Catalogo
+ Fix Home#: Titles sizes/margins
+ Fix scrolling to top, on render after a Link action
+ Fix whatsapp-icon position on -md & -lg sizes

## Test
Have no conflicts with base branch